### PR TITLE
fix: deprecatedになっていたReactDom.renderからcreateRootに修正

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
@@ -7,13 +7,15 @@ import { CookiesProvider } from "react-cookie";
 import { Provider } from "react-redux";
 import { store } from "./store";
 
-ReactDOM.render(
+const container = document.getElementById("root");
+const root = createRoot(container);
+
+root.render(
   <Provider store={store}>
     <CookiesProvider>
       <App />
     </CookiesProvider>
-  </Provider>,
-  document.getElementById("root"),
+  </Provider>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
```
npx eslint .
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .

/Users/aikawamasahiro/techtrain/frontend/react-02/railway-todo-app/src/index.js
  10:1  error  ReactDOM.render is deprecated since React 18.0.0, use createRoot instead, see https://reactjs.org/link/switch-to-createroot  react/no-deprecated

✖ 1 problem (1 error, 0 warnings)
```
プルリクタイトルの通り

