### PR TITLE
fix: prettier --write 初回実行

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
-import React from "react";
-import "./App.css";
-import { Router } from "./routes/Router";
+import React from 'react';
+import './App.css';
+import { Router } from './routes/Router';
 
 function App() {
   return (

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import App from "./App";
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import App from './App';
 
-test("renders learn react link", () => {
+test('renders learn react link', () => {
   render(<App />);
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();

--- a/src/authSlice.js
+++ b/src/authSlice.js
@@ -1,14 +1,14 @@
-import { createSlice } from "@reduxjs/toolkit";
-import { Cookies } from "react-cookie";
+import { createSlice } from '@reduxjs/toolkit';
+import { Cookies } from 'react-cookie';
 
 const cookie = new Cookies();
 
 const initialState = {
-  isSignIn: cookie.get("token") !== undefined,
+  isSignIn: cookie.get('token') !== undefined,
 };
 
 export const authSlice = createSlice({
-  name: "auth",
+  name: 'auth',
   initialState,
   reducers: {
     signIn: (state) => {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,9 +1,9 @@
-import React from "react";
-import { useCookies } from "react-cookie";
-import { useSelector, useDispatch } from "react-redux/es/exports";
-import { useNavigate } from "react-router-dom";
-import { signOut } from "../authSlice";
-import "./header.css";
+import React from 'react';
+import { useCookies } from 'react-cookie';
+import { useSelector, useDispatch } from 'react-redux/es/exports';
+import { useNavigate } from 'react-router-dom';
+import { signOut } from '../authSlice';
+import './header.css';
 
 export const Header = () => {
   const auth = useSelector((state) => state.auth.isSignIn);
@@ -12,8 +12,8 @@ export const Header = () => {
   const [cookies, setCookie, removeCookie] = useCookies();
   const handleSignOut = () => {
     dispatch(signOut());
-    removeCookie("token");
-    navigate("/signin");
+    removeCookie('token');
+    navigate('/signin');
   };
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -5,16 +5,14 @@
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
-    "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
-    "Helvetica Neue", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+    'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
 button {

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import "./index.css";
-import App from "./App";
-import reportWebVitals from "./reportWebVitals";
-import { CookiesProvider } from "react-cookie";
-import { Provider } from "react-redux";
-import { store } from "./store";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App';
+import reportWebVitals from './reportWebVitals';
+import { CookiesProvider } from 'react-cookie';
+import { Provider } from 'react-redux';
+import { store } from './store';
 
-const container = document.getElementById("root");
+const container = document.getElementById('root');
 const root = createRoot(container);
 
 root.render(
@@ -15,7 +15,7 @@ root.render(
     <CookiesProvider>
       <App />
     </CookiesProvider>
-  </Provider>,
+  </Provider>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/pages/EditList.jsx
+++ b/src/pages/EditList.jsx
@@ -1,16 +1,16 @@
-import axios from "axios";
-import React, { useEffect, useState } from "react";
-import { useCookies } from "react-cookie";
-import { useNavigate, useParams } from "react-router-dom";
-import { Header } from "../components/Header";
-import { url } from "../const";
-import "./editList.css";
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
+import { useCookies } from 'react-cookie';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Header } from '../components/Header';
+import { url } from '../const';
+import './editList.css';
 
 export const EditList = () => {
   const navigate = useNavigate();
   const { listId } = useParams();
-  const [title, setTitle] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
+  const [title, setTitle] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
   const [cookies] = useCookies();
   const handleTitleChange = (e) => setTitle(e.target.value);
   const onUpdateList = () => {
@@ -25,7 +25,7 @@ export const EditList = () => {
         },
       })
       .then(() => {
-        navigate("/");
+        navigate('/');
       })
       .catch((err) => {
         setErrorMessage(`更新に失敗しました。 ${err}`);
@@ -40,7 +40,7 @@ export const EditList = () => {
         },
       })
       .then(() => {
-        navigate("/");
+        navigate('/');
       })
       .catch((err) => {
         setErrorMessage(`削除に失敗しました。${err}`);
@@ -72,25 +72,12 @@ export const EditList = () => {
         <form className="edit-list-form">
           <label>タイトル</label>
           <br />
-          <input
-            type="text"
-            className="edit-list-title"
-            value={title}
-            onChange={handleTitleChange}
-          />
+          <input type="text" className="edit-list-title" value={title} onChange={handleTitleChange} />
           <br />
-          <button
-            type="button"
-            className="delete-list-button"
-            onClick={onDeleteList}
-          >
+          <button type="button" className="delete-list-button" onClick={onDeleteList}>
             削除
           </button>
-          <button
-            type="button"
-            className="edit-list-button"
-            onClick={onUpdateList}
-          >
+          <button type="button" className="edit-list-button" onClick={onUpdateList}>
             更新
           </button>
         </form>

--- a/src/pages/EditTask.jsx
+++ b/src/pages/EditTask.jsx
@@ -1,22 +1,22 @@
-import React, { useEffect, useState } from "react";
-import { Header } from "../components/Header";
-import axios from "axios";
-import { useCookies } from "react-cookie";
-import { url } from "../const";
-import { useNavigate, useParams } from "react-router-dom";
-import "./editTask.css";
+import React, { useEffect, useState } from 'react';
+import { Header } from '../components/Header';
+import axios from 'axios';
+import { useCookies } from 'react-cookie';
+import { url } from '../const';
+import { useNavigate, useParams } from 'react-router-dom';
+import './editTask.css';
 
 export const EditTask = () => {
   const navigate = useNavigate();
   const { listId, taskId } = useParams();
   const [cookies] = useCookies();
-  const [title, setTitle] = useState("");
-  const [detail, setDetail] = useState("");
+  const [title, setTitle] = useState('');
+  const [detail, setDetail] = useState('');
   const [isDone, setIsDone] = useState();
-  const [errorMessage, setErrorMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState('');
   const handleTitleChange = (e) => setTitle(e.target.value);
   const handleDetailChange = (e) => setDetail(e.target.value);
-  const handleIsDoneChange = (e) => setIsDone(e.target.value === "done");
+  const handleIsDoneChange = (e) => setIsDone(e.target.value === 'done');
   const onUpdateTask = () => {
     console.log(isDone);
     const data = {
@@ -33,7 +33,7 @@ export const EditTask = () => {
       })
       .then((res) => {
         console.log(res.data);
-        navigate("/");
+        navigate('/');
       })
       .catch((err) => {
         setErrorMessage(`更新に失敗しました。${err}`);
@@ -48,7 +48,7 @@ export const EditTask = () => {
         },
       })
       .then(() => {
-        navigate("/");
+        navigate('/');
       })
       .catch((err) => {
         setErrorMessage(`削除に失敗しました。${err}`);
@@ -82,21 +82,11 @@ export const EditTask = () => {
         <form className="edit-task-form">
           <label>タイトル</label>
           <br />
-          <input
-            type="text"
-            onChange={handleTitleChange}
-            className="edit-task-title"
-            value={title}
-          />
+          <input type="text" onChange={handleTitleChange} className="edit-task-title" value={title} />
           <br />
           <label>詳細</label>
           <br />
-          <textarea
-            type="text"
-            onChange={handleDetailChange}
-            className="edit-task-detail"
-            value={detail}
-          />
+          <textarea type="text" onChange={handleDetailChange} className="edit-task-detail" value={detail} />
           <br />
           <div>
             <input
@@ -105,7 +95,7 @@ export const EditTask = () => {
               name="status"
               value="todo"
               onChange={handleIsDoneChange}
-              checked={isDone === false ? "checked" : ""}
+              checked={isDone === false ? 'checked' : ''}
             />
             未完了
             <input
@@ -114,22 +104,14 @@ export const EditTask = () => {
               name="status"
               value="done"
               onChange={handleIsDoneChange}
-              checked={isDone === true ? "checked" : ""}
+              checked={isDone === true ? 'checked' : ''}
             />
             完了
           </div>
-          <button
-            type="button"
-            className="delete-task-button"
-            onClick={onDeleteTask}
-          >
+          <button type="button" className="delete-task-button" onClick={onDeleteTask}>
             削除
           </button>
-          <button
-            type="button"
-            className="edit-task-button"
-            onClick={onUpdateTask}
-          >
+          <button type="button" className="edit-task-button" onClick={onUpdateTask}>
             更新
           </button>
         </form>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,18 +1,18 @@
-import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
-import { useCookies } from "react-cookie";
-import axios from "axios";
-import { Header } from "../components/Header";
-import { url } from "../const";
-import PropTypes from "prop-types";
-import "./home.css";
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useCookies } from 'react-cookie';
+import axios from 'axios';
+import { Header } from '../components/Header';
+import { url } from '../const';
+import PropTypes from 'prop-types';
+import './home.css';
 
 export const Home = () => {
-  const [isDoneDisplay, setIsDoneDisplay] = useState("todo"); // todo->未完了 done->完了
+  const [isDoneDisplay, setIsDoneDisplay] = useState('todo'); // todo->未完了 done->完了
   const [lists, setLists] = useState([]);
   const [selectListId, setSelectListId] = useState();
   const [tasks, setTasks] = useState([]);
-  const [errorMessage, setErrorMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState('');
   const [cookies] = useCookies();
   const handleIsDoneDisplayChange = (e) => setIsDoneDisplay(e.target.value);
   useEffect(() => {
@@ -32,7 +32,7 @@ export const Home = () => {
 
   useEffect(() => {
     const listId = lists[0]?.id;
-    if (typeof listId !== "undefined") {
+    if (typeof listId !== 'undefined') {
       setSelectListId(listId);
       axios
         .get(`${url}/lists/${listId}/tasks`, {
@@ -77,9 +77,7 @@ export const Home = () => {
                 <Link to="/list/new">リスト新規作成</Link>
               </p>
               <p>
-                <Link to={`/lists/${selectListId}/edit`}>
-                  選択中のリストを編集
-                </Link>
+                <Link to={`/lists/${selectListId}/edit`}>選択中のリストを編集</Link>
               </p>
             </div>
           </div>
@@ -89,7 +87,7 @@ export const Home = () => {
               return (
                 <li
                   key={key}
-                  className={`list-tab-item ${isActive ? "active" : ""}`}
+                  className={`list-tab-item ${isActive ? 'active' : ''}`}
                   onClick={() => handleSelectList(list.id)}
                 >
                   {list.title}
@@ -103,19 +101,12 @@ export const Home = () => {
               <Link to="/task/new">タスク新規作成</Link>
             </div>
             <div className="display-select-wrapper">
-              <select
-                onChange={handleIsDoneDisplayChange}
-                className="display-select"
-              >
+              <select onChange={handleIsDoneDisplayChange} className="display-select">
                 <option value="todo">未完了</option>
                 <option value="done">完了</option>
               </select>
             </div>
-            <Tasks
-              tasks={tasks}
-              selectListId={selectListId}
-              isDoneDisplay={isDoneDisplay}
-            />
+            <Tasks tasks={tasks} selectListId={selectListId} isDoneDisplay={isDoneDisplay} />
           </div>
         </div>
       </main>
@@ -128,7 +119,7 @@ const Tasks = (props) => {
   const { tasks, selectListId, isDoneDisplay } = props;
   if (tasks === null) return <></>;
 
-  if (isDoneDisplay == "done") {
+  if (isDoneDisplay == 'done') {
     return (
       <ul>
         {tasks
@@ -137,13 +128,10 @@ const Tasks = (props) => {
           })
           .map((task, key) => (
             <li key={key} className="task-item">
-              <Link
-                to={`/lists/${selectListId}/tasks/${task.id}`}
-                className="task-item-link"
-              >
+              <Link to={`/lists/${selectListId}/tasks/${task.id}`} className="task-item-link">
                 {task.title}
                 <br />
-                {task.done ? "完了" : "未完了"}
+                {task.done ? '完了' : '未完了'}
               </Link>
             </li>
           ))}
@@ -159,13 +147,10 @@ const Tasks = (props) => {
         })
         .map((task, key) => (
           <li key={key} className="task-item">
-            <Link
-              to={`/lists/${selectListId}/tasks/${task.id}`}
-              className="task-item-link"
-            >
+            <Link to={`/lists/${selectListId}/tasks/${task.id}`} className="task-item-link">
               {task.title}
               <br />
-              {task.done ? "完了" : "未完了"}
+              {task.done ? '完了' : '未完了'}
             </Link>
           </li>
         ))}

--- a/src/pages/NewList.jsx
+++ b/src/pages/NewList.jsx
@@ -1,16 +1,16 @@
-import React, { useState } from "react";
-import { useCookies } from "react-cookie";
-import axios from "axios";
-import { Header } from "../components/Header";
-import { useNavigate } from "react-router-dom";
-import { url } from "../const";
-import "./newList.css";
+import React, { useState } from 'react';
+import { useCookies } from 'react-cookie';
+import axios from 'axios';
+import { Header } from '../components/Header';
+import { useNavigate } from 'react-router-dom';
+import { url } from '../const';
+import './newList.css';
 
 export const NewList = () => {
   const [cookies] = useCookies();
   const navigate = useNavigate();
-  const [title, setTitle] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
+  const [title, setTitle] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
   const handleTitleChange = (e) => setTitle(e.target.value);
   const onCreateList = () => {
     const data = {
@@ -24,7 +24,7 @@ export const NewList = () => {
         },
       })
       .then(() => {
-        navigate("/");
+        navigate('/');
       })
       .catch((err) => {
         setErrorMessage(`リストの作成に失敗しました。${err}`);
@@ -40,17 +40,9 @@ export const NewList = () => {
         <form className="new-list-form">
           <label>タイトル</label>
           <br />
-          <input
-            type="text"
-            onChange={handleTitleChange}
-            className="new-list-title"
-          />
+          <input type="text" onChange={handleTitleChange} className="new-list-title" />
           <br />
-          <button
-            type="button"
-            onClick={onCreateList}
-            className="new-list-button"
-          >
+          <button type="button" onClick={onCreateList} className="new-list-button">
             作成
           </button>
         </form>

--- a/src/pages/NewTask.jsx
+++ b/src/pages/NewTask.jsx
@@ -1,17 +1,17 @@
-import React, { useState, useEffect } from "react";
-import { useCookies } from "react-cookie";
-import axios from "axios";
-import { url } from "../const";
-import { Header } from "../components/Header";
-import "./newTask.css";
-import { useNavigate } from "react-router-dom";
+import React, { useState, useEffect } from 'react';
+import { useCookies } from 'react-cookie';
+import axios from 'axios';
+import { url } from '../const';
+import { Header } from '../components/Header';
+import './newTask.css';
+import { useNavigate } from 'react-router-dom';
 
 export const NewTask = () => {
   const [selectListId, setSelectListId] = useState();
   const [lists, setLists] = useState([]);
-  const [title, setTitle] = useState("");
-  const [detail, setDetail] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
+  const [title, setTitle] = useState('');
+  const [detail, setDetail] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
   const [cookies] = useCookies();
   const navigate = useNavigate();
   const handleTitleChange = (e) => setTitle(e.target.value);
@@ -31,7 +31,7 @@ export const NewTask = () => {
         },
       })
       .then(() => {
-        navigate("/");
+        navigate('/');
       })
       .catch((err) => {
         setErrorMessage(`タスクの作成に失敗しました。${err}`);
@@ -63,10 +63,7 @@ export const NewTask = () => {
         <form className="new-task-form">
           <label>リスト</label>
           <br />
-          <select
-            onChange={(e) => handleSelectList(e.target.value)}
-            className="new-task-select-list"
-          >
+          <select onChange={(e) => handleSelectList(e.target.value)} className="new-task-select-list">
             {lists.map((list, key) => (
               <option key={key} className="list-item" value={list.id}>
                 {list.title}
@@ -76,25 +73,13 @@ export const NewTask = () => {
           <br />
           <label>タイトル</label>
           <br />
-          <input
-            type="text"
-            onChange={handleTitleChange}
-            className="new-task-title"
-          />
+          <input type="text" onChange={handleTitleChange} className="new-task-title" />
           <br />
           <label>詳細</label>
           <br />
-          <textarea
-            type="text"
-            onChange={handleDetailChange}
-            className="new-task-detail"
-          />
+          <textarea type="text" onChange={handleDetailChange} className="new-task-detail" />
           <br />
-          <button
-            type="button"
-            className="new-task-button"
-            onClick={onCreateTask}
-          >
+          <button type="button" className="new-task-button" onClick={onCreateTask}>
             作成
           </button>
         </form>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 
 export const NotFound = () => {
   return <h1>Sorry, Not found</h1>;

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -1,19 +1,19 @@
-import React, { useState } from "react";
-import axios from "axios";
-import { useCookies } from "react-cookie";
-import { Navigate, useNavigate, Link } from "react-router-dom";
-import { Header } from "../components/Header";
-import "./signin.css";
-import { useDispatch, useSelector } from "react-redux";
-import { signIn } from "../authSlice";
-import { url } from "../const";
+import React, { useState } from 'react';
+import axios from 'axios';
+import { useCookies } from 'react-cookie';
+import { Navigate, useNavigate, Link } from 'react-router-dom';
+import { Header } from '../components/Header';
+import './signin.css';
+import { useDispatch, useSelector } from 'react-redux';
+import { signIn } from '../authSlice';
+import { url } from '../const';
 
 export const SignIn = () => {
   const auth = useSelector((state) => state.auth.isSignIn);
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   const [errorMessage, setErrorMessage] = useState();
   const [cookies, setCookie, removeCookie] = useCookies();
   const handleEmailChange = (e) => setEmail(e.target.value);
@@ -22,9 +22,9 @@ export const SignIn = () => {
     axios
       .post(`${url}/signin`, { email: email, password: password })
       .then((res) => {
-        setCookie("token", res.data.token);
+        setCookie('token', res.data.token);
         dispatch(signIn());
-        navigate("/");
+        navigate('/');
       })
       .catch((err) => {
         setErrorMessage(`サインインに失敗しました。${err}`);
@@ -42,19 +42,11 @@ export const SignIn = () => {
         <form className="signin-form">
           <label className="email-label">メールアドレス</label>
           <br />
-          <input
-            type="email"
-            className="email-input"
-            onChange={handleEmailChange}
-          />
+          <input type="email" className="email-input" onChange={handleEmailChange} />
           <br />
           <label className="password-label">パスワード</label>
           <br />
-          <input
-            type="password"
-            className="password-input"
-            onChange={handlePasswordChange}
-          />
+          <input type="password" className="password-input" onChange={handlePasswordChange} />
           <br />
           <button type="button" className="signin-button" onClick={onSignIn}>
             サインイン

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,20 +1,20 @@
-import axios from "axios";
-import React, { useState } from "react";
-import { useCookies } from "react-cookie";
-import { useSelector, useDispatch } from "react-redux";
-import { useNavigate, Navigate } from "react-router-dom";
-import { signIn } from "../authSlice";
-import { Header } from "../components/Header";
-import { url } from "../const";
-import "./signUp.css";
+import axios from 'axios';
+import React, { useState } from 'react';
+import { useCookies } from 'react-cookie';
+import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate, Navigate } from 'react-router-dom';
+import { signIn } from '../authSlice';
+import { Header } from '../components/Header';
+import { url } from '../const';
+import './signUp.css';
 
 export const SignUp = () => {
   const navigate = useNavigate();
   const auth = useSelector((state) => state.auth.isSignIn);
   const dispatch = useDispatch();
-  const [email, setEmail] = useState("");
-  const [name, setName] = useState("");
-  const [password, setPassword] = useState("");
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
   const [errorMessage, setErrorMessge] = useState();
   const [cookies, setCookie, removeCookie] = useCookies();
   const handleEmailChange = (e) => setEmail(e.target.value);
@@ -32,8 +32,8 @@ export const SignUp = () => {
       .then((res) => {
         const token = res.data.token;
         dispatch(signIn());
-        setCookie("token", token);
-        navigate("/");
+        setCookie('token', token);
+        navigate('/');
       })
       .catch((err) => {
         setErrorMessge(`サインアップに失敗しました。 ${err}`);
@@ -50,27 +50,15 @@ export const SignUp = () => {
         <form className="signup-form">
           <label>メールアドレス</label>
           <br />
-          <input
-            type="email"
-            onChange={handleEmailChange}
-            className="email-input"
-          />
+          <input type="email" onChange={handleEmailChange} className="email-input" />
           <br />
           <label>ユーザ名</label>
           <br />
-          <input
-            type="text"
-            onChange={handleNameChange}
-            className="name-input"
-          />
+          <input type="text" onChange={handleNameChange} className="name-input" />
           <br />
           <label>パスワード</label>
           <br />
-          <input
-            type="password"
-            onChange={handlePasswordChange}
-            className="password-input"
-          />
+          <input type="password" onChange={handlePasswordChange} className="password-input" />
           <br />
           <button type="button" onClick={onSignUp} className="signup-button">
             作成

--- a/src/reportWebVitals.js
+++ b/src/reportWebVitals.js
@@ -1,6 +1,6 @@
 const reportWebVitals = (onPerfEntry) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
       getCLS(onPerfEntry);
       getFID(onPerfEntry);
       getFCP(onPerfEntry);

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,14 +1,14 @@
-import React from "react";
-import { useSelector } from "react-redux";
-import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
-import { Home } from "../pages/Home";
-import { NotFound } from "../pages/NotFound";
-import { SignIn } from "../pages/SignIn";
-import { NewTask } from "../pages/NewTask";
-import { NewList } from "../pages/NewList";
-import { EditTask } from "../pages/EditTask";
-import { SignUp } from "../pages/SignUp";
-import { EditList } from "../pages/EditList";
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom';
+import { Home } from '../pages/Home';
+import { NotFound } from '../pages/NotFound';
+import { SignIn } from '../pages/SignIn';
+import { NewTask } from '../pages/NewTask';
+import { NewList } from '../pages/NewList';
+import { EditTask } from '../pages/EditTask';
+import { SignUp } from '../pages/SignUp';
+import { EditList } from '../pages/EditList';
 
 export const Router = () => {
   const auth = useSelector((state) => state.auth.isSignIn);

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import "@testing-library/jest-dom";
+import '@testing-library/jest-dom';

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,5 @@
-import { configureStore } from "@reduxjs/toolkit";
-import { authSlice } from "./authSlice";
+import { configureStore } from '@reduxjs/toolkit';
+import { authSlice } from './authSlice';
 
 export const store = configureStore({
   reducer: {


### PR DESCRIPTION
.prettierrc.jsは以下
```
module.exports = {
  printWidth: 120, // max 120 chars in line, code is easy to read
  useTabs: false, // use spaces instead of tabs
  tabWidth: 2, // "visual width" of of the "tab"
  trailingComma: 'es5', // add trailing commas in objects, arrays, etc.
  semi: true, // add ; when needed
  singleQuote: true, // '' for stings instead of ""
  bracketSpacing: true, // import { some } ... instead of import {some} ...
  arrowParens: 'always', // braces even for single param in arrow functions (a) => { }
  jsxSingleQuote: false, // "" for react props, like in html
  bracketSameLine: false, // pretty JSX
  endOfLine: 'lf', // 'lf' for linux, 'crlf' for windows, we need to use 'lf' for git
};
```