### PR TITLE
fix: .vscodeを.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ yarn-debug.log*
 yarn-error.log*
 
 .env
+
+# vscode
+.vscode


### PR DESCRIPTION
VSCodeの左ペインの上から4つ目のデバッグ機能を有効化したことによりできたディレクトリ