### PR TITLE
feat: editTaskの初期値を修正 期限日時の表記を変更

### DIFF
--- a/src/pages/EditTask.jsx
+++ b/src/pages/EditTask.jsx
@@ -5,6 +5,12 @@ import { useCookies } from 'react-cookie';
 import { url } from '../const';
 import { useNavigate, useParams } from 'react-router-dom';
 import './editTask.scss';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export const EditTask = () => {
   const navigate = useNavigate();
@@ -17,21 +23,18 @@ export const EditTask = () => {
   const [errorMessage, setErrorMessage] = useState('');
   const handleTitleChange = (e) => setTitle(e.target.value);
   const handleDetailChange = (e) => setDetail(e.target.value);
-  const handleLimitChange = (e) => setLimit(e.target.value);
+  const handleLimitChange = (e) => {
+    const localDate = dayjs(e.target.value);
+    const utcDate = localDate.utc();
+    setLimit(utcDate);
+  };
   const handleIsDoneChange = (e) => setIsDone(e.target.value === 'done');
   const onUpdateTask = () => {
-    function convertUTCToJST(utcDateStr) {
-      const date = new Date(utcDateStr);
-      const JSTOffset = 9 * 60 * 60 * 1000; //ミリ秒単位
-      const jstDate = new Date(date.getTime() + JSTOffset);
-      return jstDate;
-    }
-
     const data = {
       title: title,
       detail: detail,
       done: isDone,
-      limit: convertUTCToJST(limit).toISOString(),
+      limit: limit.toISOString(),
     };
 
     axios
@@ -76,7 +79,7 @@ export const EditTask = () => {
         setTitle(task.title);
         setDetail(task.detail);
         setIsDone(task.done);
-        setLimit(task.limit);
+        setLimit(dayjs(task.limit));
       })
       .catch((err) => {
         setErrorMessage(`タスク情報の取得に失敗しました。${err}`);
@@ -100,7 +103,12 @@ export const EditTask = () => {
           <br />
           <label>期限</label>
           <br />
-          <input type="datetime-local" onChange={handleLimitChange} className="edit-task-limit" value={limit} />
+          <input
+            type="datetime-local"
+            onChange={handleLimitChange}
+            className="edit-task-limit"
+            value={dayjs.utc(limit).tz(dayjs.tz.guess()).format('YYYY-MM-DDTHH:mm')}
+          />
           <br />
           <div>
             <input

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -6,6 +6,12 @@ import { Header } from '../components/Header';
 import { url } from '../const';
 import PropTypes from 'prop-types';
 import './home.scss';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export const Home = () => {
   const [isDoneDisplay, setIsDoneDisplay] = useState('todo'); // todo->未完了 done->完了
@@ -119,10 +125,9 @@ const Tasks = (props) => {
   const { tasks, selectListId, isDoneDisplay } = props;
 
   function calculateRemainingTime(isoString) {
-    const limitDate = new Date(isoString);
-    const nowDateUTC = new Date();
-    const nowDateJST = nowDateUTC.setHours(nowDateUTC.getHours() + 9);
-    const diffMs = limitDate - nowDateJST;
+    const limitDateUTC = dayjs(isoString);
+    const nowDateUTC = dayjs();
+    const diffMs = limitDateUTC - nowDateUTC;
 
     if (diffMs <= 0) {
       return '期限切れ';
@@ -150,7 +155,7 @@ const Tasks = (props) => {
               <Link to={`/lists/${selectListId}/tasks/${task.id}`} className="task-item-link">
                 タイトル：{task.title}
                 <br />
-                期限日時：{task.limit}
+                期限日時：{dayjs(task.limit).tz(dayjs.tz.guess()).format('YYYY-MM-DD HH:mm')}
                 <br />
                 残り日時：{calculateRemainingTime(task.limit)}
                 <br />
@@ -173,7 +178,7 @@ const Tasks = (props) => {
             <Link to={`/lists/${selectListId}/tasks/${task.id}`} className="task-item-link">
               タイトル：{task.title}
               <br />
-              期限日時：{task.limit}
+              期限日時：{dayjs(task.limit).tz(dayjs.tz.guess()).format('YYYY-MM-DD HH:mm')}
               <br />
               残り日時：{calculateRemainingTime(task.limit)}
               <br />

--- a/src/pages/NewTask.jsx
+++ b/src/pages/NewTask.jsx
@@ -5,6 +5,12 @@ import { url } from '../const';
 import { Header } from '../components/Header';
 import './newTask.scss';
 import { useNavigate } from 'react-router-dom';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export const NewTask = () => {
   const [selectListId, setSelectListId] = useState();
@@ -17,7 +23,11 @@ export const NewTask = () => {
   const navigate = useNavigate();
   const handleTitleChange = (e) => setTitle(e.target.value);
   const handleDetailChange = (e) => setDetail(e.target.value);
-  const handleLimitChange = (e) => setLimit(e.target.value);
+  const handleLimitChange = (e) => {
+    const localDate = dayjs(e.target.value);
+    const utcDate = localDate.utc();
+    setLimit(utcDate);
+  };
   const handleSelectList = (id) => setSelectListId(id);
   const onCreateTask = () => {
     function convertUTCToJST(utcDateStr) {
@@ -31,7 +41,7 @@ export const NewTask = () => {
       title: title,
       detail: detail,
       done: false,
-      limit: convertUTCToJST(limit).toISOString(),
+      limit: limit.toISOString(),
     };
 
     axios


### PR DESCRIPTION
* 型の違いによりタスク編集画面でinput要素にvalueとして初期値を入れられていなかった点を修正
* dayjsによりローカルのタイムゾーンを参照し、期限日時に設定できるように変更

タスク新規作成・編集時のデータの型や書式変換の流れ
1. input要素からローカルのdatetime-localを取得
2. ローカルのDate型に変更
3. dayjsによりUTCのDate型に変更、ここでsetLimitでUTCのDate型をStateで持つ
4. ISOString型に変更し、POST

GETして画面に表示する流れはその逆になります。